### PR TITLE
Removing some redundancy.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { render } from "react-dom";
 
 import './index.css';
 import App from './main-page/app';
-import { BrowserRouter} from "react-router-dom";
-import reportWebVitals from './reportWebVitals';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
-      <App />
-  </React.StrictMode>
-  ,
+    <App />
+  </React.StrictMode>,
   document.getElementById('root')
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+// Performance measurement for your app. To use, pass a function to log results, for example:
+// reportWebVitals(console.log)
+// For more information, visit: https://bit.ly/CRA-vitals
 reportWebVitals();


### PR DESCRIPTION
The `ReactDOM.render` method is already being used for rendering, making the render import unnecessary.